### PR TITLE
Change autosan middleware to apply each filter to each input field

### DIFF
--- a/src/Http/Middleware/AutoSan.php
+++ b/src/Http/Middleware/AutoSan.php
@@ -15,39 +15,26 @@ class AutoSan
         $this->sanitizr = $sanitizr;
     }
 
-    public function handle(Request $request, Closure $next, $rulesString = '')
+    public function handle(Request $request, Closure $next, array $rules = [])
     {
-        $rules = $this->parseRules($rulesString);
         $data = $request->all();
-        $sanitizedData = $this->sanitizr->sanitize($data, $rules);
+        $filters = $this->getFilters($rules);
+        $sanitizedData = $this->sanitizr->sanitize($data, $filters);
         $request->merge($sanitizedData);
 
         return $next($request);
     }
 
-    protected function parseRules($rulesString): array
-    {
-        $rules = [];
-        $fields = explode(';', $rulesString);
 
-        foreach ($fields as $field) {
-            list($fieldName, $fieldRules) = explode(',', $field);
-            $rules[$fieldName] = $this->getFilters($fieldRules);
-        }
-
-        return $rules;
-    }
-
-    protected function getFilters($fieldRules): array
+    protected function getFilters(array $rules): array
     {
         $filters = [];
-        $rules = explode('|', $fieldRules);
 
-        foreach ($rules as $rule) {
-            if (config("sanitizr.rules.$rule")) {
-                $filters = array_merge($filters, config("sanitizr.rules.$rule"));
-            } else {
-                $filters[] = $rule;
+        if (!empty($rules)) {
+            foreach ($rules as $rule) {
+                if (config("sanitizr.rules.$rule")) {
+                    $filters = array_merge($filters, config("sanitizr.rules.$rule"));
+                }
             }
         }
 

--- a/src/Services/SanitizrService.php
+++ b/src/Services/SanitizrService.php
@@ -2,6 +2,8 @@
 
 namespace AnomanderRevan\Sanitizr\Services;
 
+use Illuminate\Support\Facades\Log;
+
 class SanitizrService
 {
     protected array $filters;
@@ -11,14 +13,20 @@ class SanitizrService
         $this->filters = $filters;
     }
 
-    public function sanitize(array $data, array $rules): array
+    public function sanitize(array $data, array $filters): array
     {
-        foreach ($rules as $field => $fieldFilters) {
-            if (isset($data[$field])) {
-                foreach ($fieldFilters as $filter) {
-                    if (isset($this->filters[$filter])) {
-                        $data[$field] = call_user_func($this->filters[$filter], $data[$field]);
+        if (!empty($filters) && !empty($data)) {
+            foreach ($filters as $filter) {
+                if (isset($this->filters[$filter])) {
+                    if (is_callable($this->filters[$filter])) {
+                        foreach ($data as $key => $value) {
+                            $data[$key] = call_user_func($this->filters[$filter], $value);
+                        }
+                    } else {
+                        Log::error("Filter '$filter' is not callable");
                     }
+                } else {
+                    Log::error("Filter '$filter' is not defined");
                 }
             }
         }


### PR DESCRIPTION
Originally the AutoSan middleware was designed to apply a given filter to a given field. I've changed this approach to apply all filters in a given rule to each field in the $request.