### PR TITLE
Filters not being passed to Service. Defaulting to config

### DIFF
--- a/src/Services/SanitizrService.php
+++ b/src/Services/SanitizrService.php
@@ -10,7 +10,7 @@ class SanitizrService
 
     public function __construct(array $filters = [])
     {
-        $this->filters = $filters;
+        $this->filters = $filters ?? config('sanitizr.filters');
     }
 
     public function sanitize(array $data, array $filters): array


### PR DESCRIPTION
The SanitizrService should be receiving the array of filters from the SanitizrServiceProvider during registration but there is nothing there when the class is instanciated in the app. 

I'm not sure why this is happening yet so for now if the argument is an empty array the instantiated class will find them from the config.

